### PR TITLE
refactored events and close popup on esc

### DIFF
--- a/core.py
+++ b/core.py
@@ -256,7 +256,7 @@ class Widget(object):
 
 			self.element.addEventListener(event, eventFn)
 
-	# print("sink", eventFn)
+			# print("sink", event, eventFn)
 
 	def unsinkEvent(self, *args):
 		for event_attrName in args:
@@ -2985,42 +2985,47 @@ def parseFloat(s, ret=0.0):
 # Keycodes
 ########################################################################################################################
 
-def isSingleSelectionKey(keyCode):
+def getKey(event):
 	"""
-		Tests wherever keyCode means the modifier key for single selection
+	Returns the Key Identifier of the given event
+
+	Available Codes: https://www.w3.org/TR/2006/WD-DOM-Level-3-Events-20060413/keyset.html#KeySet-Set
 	"""
-	if keyCode == 17:  # "ctrl" on all major platforms
-		return True
+	if hasattr(event, "key"):
+		return event.key
 
-	elif eval("navigator.appVersion.indexOf(\"Mac\") != -1"):  # "cmd" on the broken one
-		if keyCode in [224, 17, 91, 93]:
-			return True
+	elif hasattr(event, "keyIdentifier"):
+		if event.keyIdentifier in ["Esc", "U+001B"]:
+			return "Escape"
+		else:
+			return event.keyIdentifier
 
-	return False
-
-
-def isArrowLeft(keyCode):
-	return keyCode == 37
+	return None
 
 
-def isArrowUp(keyCode):
-	return keyCode == 38
+def isArrowLeft(event):
+	return getKey(event) == "Left"
 
+def isArrowUp(event):
+	return getKey(event) == "Up"
 
-def isArrowRight(keyCode):
-	return keyCode == 39
+def isArrowRight(event):
+	return getKey(event) == "Right"
 
+def isArrowDown(event):
+	return getKey(event) == "Down"
 
-def isArrowDown(keyCode):
-	return keyCode == 40
+def isEscape(event):
+	return getKey(event) == "Escape"
 
+def isReturn(event):
+	return getKey(event) == "Enter"
 
-def isReturn(keyCode):
-	return keyCode == 13
+def isControl(event): # The Control (Ctrl) key.
+	return getKey(event) == "Control"
 
-
-def isShift(keyCode):
-	return keyCode == 16
+def isShift(event):
+	return getKey(event) == "Shift"
 
 
 ########################################################################################################################

--- a/ext.py
+++ b/ext.py
@@ -70,7 +70,7 @@ class Input(html5.Input):
 
 
 class Popup(html5.Div):
-	def __init__(self, title=None, id=None, className=None, *args, **kwargs):
+	def __init__(self, title=None, id=None, className=None, enableShortcuts=True, *args, **kwargs):
 		super(Popup, self).__init__(*args, **kwargs)
 
 		self["class"] = "alertbox"
@@ -86,11 +86,28 @@ class Popup(html5.Div):
 		# id can be used to pass information to callbacks
 		self.id = id
 
+		self.enableShortcuts = enableShortcuts
+
 		self.frameDiv = html5.Div()
 		self.frameDiv["class"] = "popup"
 
 		self.frameDiv.appendChild(self)
 		html5.Body().appendChild(self.frameDiv)
+
+	def onAttach(self):
+		super(Popup, self)
+		if self.enableShortcuts:
+			self.onDocumentKeyDownMethod = self.onDocumentKeyDown  # safe reference to method
+			html5.document.addEventListener("keydown", self.onDocumentKeyDownMethod)
+
+	def onDetach(self):
+		super(Popup, self)
+		if self.enableShortcuts:
+			html5.document.removeEventListener("keydown", self.onDocumentKeyDownMethod)
+
+	def onDocumentKeyDown(self, event):
+		if html5.isEscape(event):
+			self.close()
 
 	def close(self, *args, **kwargs):
 		html5.Body().removeChild(self.frameDiv)
@@ -118,23 +135,17 @@ class InputDialog(Popup):
 		cancelBtn = Button(abortLbl, self.onCancel)
 		cancelBtn["class"].append("btn_cancel")
 		self.appendChild(cancelBtn)
-		self.sinkEvent("onkeydown")
+		self.sinkEvent("onKeyDown")
 		self.inputElem.focus()
 
-	def onkeydown(self, event):
-		if hasattr(event, "key"):
-			key = event.key
-		elif hasattr(event, "keyIdentifier"):
-			# Babelfish: Translate "keyIdentifier" into "key"
-			if event.keyIdentifier in ["Esc", "U+001B"]:
-				key = "Escape"
-			else:
-				key = event.keyIdentifier
-		if "Enter" == key:
+	def onKeyDown(self, event):
+		if html5.isReturn(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onOkay()
-		elif "Escape" == key:
+
+	def onDocumentKeyDown(self, event):
+		if html5.isEscape(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onCancel()
@@ -188,14 +199,7 @@ class Alert(Popup):
 		self.drop()
 
 	def onKeyDown(self, event):
-		if hasattr(event, "key"):
-			key = event.key
-		elif hasattr(event, "keyIdentifier"):
-			key = event.keyIdentifier
-		else:
-			key = None
-
-		if key == "Enter":
+		if html5.isReturn(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onOkBtnClick()
@@ -228,26 +232,17 @@ class YesNoDialog(Popup):
 			btnNo["class"].append("btn_no")
 			self.appendChild(btnNo)
 
-		self.sinkEvent("onkeydown")
+		self.sinkEvent("onKeyDown")
 		btnYes.focus()
 
-	def onkeydown(self, event):
-		if hasattr(event, "key"):
-			key = event.key
-		elif hasattr(event, "keyIdentifier"):
-			# Babelfish: Translate "keyIdentifier" into "key"
-			if event.keyIdentifier in ["Esc", "U+001B"]:
-				key = "Escape"
-			else:
-				key = event.keyIdentifier
-		else:
-			key = None
-
-		if "Enter" == key:
+	def onKeyDown(self, event):
+		if html5.isReturn(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onYesClicked()
-		elif "Escape" == key:
+
+	def onDocumentKeyDown(self, event):
+		if html5.isEscape(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onNoClicked()
@@ -385,24 +380,11 @@ class TextareaDialog(Popup):
 		cancelBtn = Button(abortLbl, self.onCancel)
 		cancelBtn["class"].append("btn_cancel")
 		self.appendChild(cancelBtn)
-		self.sinkEvent("onkeydown")
+		self.sinkEvent("onKeyDown")
 		self.inputElem.focus()
 
-	def onkeydown(self, event):
-		if hasattr(event, "key"):
-			key = event.key
-		elif hasattr(event, "keyIdentifier"):
-			# Babelfish: Translate "keyIdentifier" into "key"
-			if event.keyIdentifier in ["Esc", "U+001B"]:
-				key = "Escape"
-			else:
-				key = event.keyIdentifier
-
-		# Some keys have special treatment
-		if "Enter" == key:
-			pass
-
-		elif "Escape" == key:
+	def onDocumentKeyDown(self, event):
+		if html5.isEscape(event):
 			event.stopPropagation()
 			event.preventDefault()
 			self.onCancel()


### PR DESCRIPTION
event.keyCode is deprecated. It's recommended to use key and keyIdentifier instead.
see: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode

It's now also possible to close Popups by pressing _Escape_ You can define other keybinding by redefine the method `onDocumentKeyDown`
