### PR TITLE
Improving the HTML parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 
 This file documents any relevant changes done to ViUR html5 since version 2.
 
-## [develop] 
+## [develop] Vesuv
 
 This is the current development version.
 
 - Bugfix: `Widget.Th()` now supporting full col-/rowspan getting and setting.
+- Bugfix: Build-in HTML parser accepts tags in upper-/camel-case order now.
+- Bugfix: Build-in HTML parser handles table tags with tbody/thead tags inside more gracefully.
 - Feature: New function `Widget.isVisible()` as counterpart for `Widget.isHidden()`.
 
 ## [2.4.0] Agung

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ This file documents any relevant changes done to ViUR html5 since version 2.
 This is the current development version.
 
 - Bugfix: `Widget.Th()` now supporting full col-/rowspan getting and setting.
-- Bugfix: Build-in HTML parser accepts tags in upper-/camel-case order now.
-- Bugfix: Build-in HTML parser handles table tags with tbody/thead tags inside more gracefully.
+- Bugfix: HTML-parser accepts tags in upper-/camel-case order now.
+- Bugfix: HTML-parser handles table tags with tbody/thead tags inside more gracefully.
+- Feature: Split HTML-parser into separate stages to compile and run; This allows to pre-compile HTML into a list/dict-structure and render it later on without parsing it again. `parseHTML()` is the new function, `fromHTML()` works like before and handles pre-compiled or raw HTML as parameter.
+- Feature: `fromHTML()` extended to `vars` parameter to replace key-value pairs in text-nodes and attribute values expressed as `{{key}}`.
 - Feature: New function `Widget.isVisible()` as counterpart for `Widget.isHidden()`.
 
 ## [2.4.0] Agung

--- a/core.py
+++ b/core.py
@@ -3214,7 +3214,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 				junk += tag
 
 				# print("/", tag.lower(), stack[-1][1].lower())
-				if stack[-1][1].lower() == tag.lower():
+				if stack[-1][1] == tag.lower():
 					junk += scanWhite(html)
 					if html and html[0] == ">":
 						html.pop(0)
@@ -3236,9 +3236,17 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 
 		# Create tag
 		if tag:
-			wdg = __tags[tag][0]()
+			tag = tag.lower()
 
-			parent.appendChild(wdg)
+			# Special handling for tables: A "thead" and "tbody" are already part of table!
+			if tag in ["thead", "tbody"] and isinstance(parent, Table):
+				wdg = getattr(stack[-1][0], tag[1:])
+
+			# Usual way: Construct new element and chain it into the parent.
+			else:
+				wdg = __tags[tag][0]()
+				parent.appendChild(wdg)
+
 			stack.append((wdg, tag))
 
 			# print("tag", tag)

--- a/core.py
+++ b/core.py
@@ -3405,6 +3405,8 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
 
 	interpret(appendTo, html)
 
+	return html #return compiled HTML (for optional reuse)
+
 
 if __name__ == '__main__':
 	print(globals())

--- a/core.py
+++ b/core.py
@@ -3237,19 +3237,17 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 		# Create tag
 		if tag:
 			tag = tag.lower()
+			# print("tag", tag)
 
 			# Special handling for tables: A "thead" and "tbody" are already part of table!
 			if tag in ["thead", "tbody"] and isinstance(parent, Table):
-				wdg = getattr(stack[-1][0], tag[1:])
+				wdg = getattr(parent, tag[1:])
 
 			# Usual way: Construct new element and chain it into the parent.
 			else:
 				wdg = __tags[tag][0]()
-				parent.appendChild(wdg)
 
 			stack.append((wdg, tag))
-
-			# print("tag", tag)
 
 			while html:
 				scanWhite(html)
@@ -3317,17 +3315,17 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 
 					elif att == "class":
 						# print(tag, att, val.split())
-						stack[-1][0].addClass(*val.split())
+						wdg.addClass(*val.split())
 
 					elif att == "disabled":
 						# print(tag, att, val)
 						if val == "disabled":
-							stack[-1][0].disable()
+							wdg.disable()
 
 					elif att == "hidden":
 						# print(tag, att, val)
 						if val == "hidden":
-							stack[-1][0].hide()
+							wdg.hide()
 
 					elif att == "style":
 						for dfn in val.split(";"):
@@ -3337,16 +3335,19 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 							att, val = dfn.split(":", 1)
 
 							# print(tag, "style", att.strip(), val.strip())
-							stack[-1][0]["style"][att.strip()] = val.strip()
+							wdg["style"][att.strip()] = val.strip()
 
 					elif att.startswith("data-"):
-						stack[-1][0]["data"][att[5:]] = val
+						wdg["data"][att[5:]] = val
 
 					else:
 						# print(tag, att, val)
-						stack[-1][0][att] = val
+						wdg[att] = val
 
 				continue
+
+			if not wdg.parent():
+				parent.appendChild(wdg)
 
 
 if __name__ == '__main__':

--- a/core.py
+++ b/core.py
@@ -4,8 +4,20 @@
 # DOM-access functions and variables
 ########################################################################################################################
 
-window = eval("window.top")
-document = window.document
+try:
+	# PyJS
+	jseval = eval
+
+	window = jseval("window.top")
+	document = window.document
+
+except NameError:
+	print("Emulation mode")
+	from xml.dom.minidom import parseString
+	jseval = None
+
+	window = None
+	document = parseString('<html><head /><body /></html>')
 
 
 def domCreateAttribute(tag, ns=None):
@@ -946,7 +958,7 @@ class Widget(object):
 			self.element.removeChild(c.element)
 			self.element.insertBefore(c.element, self.element.children.item(0))
 
-	def fromHTML(self, html, appendTo=None, bindTo=None):
+	def fromHTML(self, html, appendTo=None, bindTo=None, vars=None):
 		"""
 		Parses html and constructs its elements as part of self.
 
@@ -964,7 +976,7 @@ class Widget(object):
 		if bindTo is None:
 			bindTo = self
 
-		return fromHTML(html, appendTo, bindTo)
+		return fromHTML(html, appendTo=appendTo, bindTo=bindTo, vars=vars)
 
 
 ########################################################################################################################
@@ -3042,92 +3054,68 @@ __tags = None
 __domParser = None
 
 
-def __convertEncodedText(txt):
+def parseHTML(html, debug=False):
 	"""
-	Convert HTML-encoded text into decoded string.
-
-	The reason for this function is the handling of HTML entities, which is not
-	properly supported by native JavaScript.
-
-	We use the browser's DOM parser to to this, according to
-	https://stackoverflow.com/questions/3700326/decode-amp-back-to-in-javascript
-
-	:param txt: The encoded text.
-	:return: The decoded text.
+	Parses the provided HTML-code according to the objects defined in the html5-library.
 	"""
-	global __domParser
 
-	if __domParser is None:
-		__domParser = eval("new DOMParser")
+	def buildDescription():
+		"""
+		Generates a dictionary of all to the html5-library
+		known tags and their associated objects and attributes.
+		"""
+		tags = {}
 
-	dom = __domParser.parseFromString("<!doctype html><body>" + str(txt), "text/html")
-	return dom.body.textContent
-
-
-def __buildDescription(debug = False):
-	"""
-	Generates a dictionary of all to the html5-library
-	known tags and their associated objects and attributes.
-	"""
-	tags = {}
-
-	for cname in globals().keys():
-		if cname.startswith("_"):
-			continue
-
-		cl = globals()[cname]
-
-		try:
-			if not issubclass(cl, Widget):
+		for cname in globals().keys():
+			if cname.startswith("_"):
 				continue
-		except:
-			continue
 
-		attr = []
+			cl = globals()[cname]
 
-		for fname in dir(cl):
-			if fname.startswith("_set"):
-				attr.append(fname[4:].lower())
+			try:
+				if not issubclass(cl, Widget):
+					continue
+			except:
+				continue
 
-		tags[cname.lower()] = (cl, attr)
-	# print(cname, cl, attr)
+			attr = []
 
-	if debug:
-		for tag in sorted(tags.keys()):
-			print("{}: {}".format(tag, ", ".join(sorted(tags[tag][1]))))
+			for fname in dir(cl):
+				if fname.startswith("_set"):
+					attr.append(fname[4:].lower())
 
-	return tags
+			tags[cname.lower()] = (cl, attr)
+		# print(cname, cl, attr)
 
+		if debug:
+			for tag in sorted(tags.keys()):
+				print("{}: {}".format(tag, ", ".join(sorted(tags[tag][1]))))
 
-def fromHTML(html, appendTo=None, bindTo=None, debug=False):
-	"""
-	Parses the provided HTML code according to the objects defined in the html5-library.
+		return tags
 
-	Constructs all objects as DOM nodes. The first level is chained into root.
-	If no root is provided, root will be set to html5.Body().
+	def convertEncodedText(txt):
+		"""
+		Convert HTML-encoded text into decoded string.
 
-	The HTML elements are parsed for notations of kind [name]="ident", making
-	the corresponding instance available to the widget as widget.ident in the
-	Python code.
+		The reason for this function is the handling of HTML entities, which is not
+		properly supported by native JavaScript.
 
-	Example:
+		We use the browser's DOM parser to to this, according to
+		https://stackoverflow.com/questions/3700326/decode-amp-back-to-in-javascript
 
-	```python
-	import html5
+		:param txt: The encoded text.
+		:return: The decoded text.
+		"""
+		global __domParser
 
-	div = html5.Div()
-	html5.parse.fromHTML('''
-		<div>Yeah!
-			<a href="hello world" [name]="myLink" class="trullman bernd" disabled>
-			hah ala malla" bababtschga"
-			<img src="/static/images/icon_home.svg" style="background-color: red;"/>st
-			<em>ah</em>ralla <i>malla tralla</i> da
-			</a>lala
-		</div>''', div)
+		if jseval is None:
+			return txt
 
-	div.myLink.appendChild("appended!")
-	```
-	"""
+		if __domParser is None:
+			__domParser = jseval("new DOMParser")
+
+		dom = __domParser.parseFromString("<!doctype html><body>" + str(txt), "text/html")
+		return dom.body.textContent
 
 	def scanWhite(l):
 		"""
@@ -3156,17 +3144,10 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 
 	# Obtain tag descriptions
 	if __tags is None:
-		__tags = __buildDescription()
-
-	# Handle defaults
-	if appendTo is None:
-		appendTo = Body()
-
-	if bindTo is None:
-		bindTo = appendTo
+		__tags = buildDescription()
 
 	# Prepare stack and input
-	stack.append((appendTo, None))
+	stack.append((None, None, []))
 	html = [ch for ch in html]
 
 	# Parse
@@ -3175,13 +3156,13 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 		text = ""
 
 		# ugly...
-		while stack and stack[-1][1] in ["br", "input", "img"]:
+		while stack and stack[-1][0] in ["br", "input", "img"]:
 			stack.pop()
 
 		if not stack:
 			break
 
-		parent = stack[-1][0]
+		parent = stack[-1][2]
 
 		while html:
 			# print("html", html)
@@ -3206,7 +3187,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 				text += ch + tag
 
 			# Closing tag
-			elif html and stack[-1][1] and ch == "<" and html[0] == "/":
+			elif html and stack[-1][0] and ch == "<" and html[0] == "/":
 				junk = ch
 				junk += html.pop(0)
 
@@ -3214,7 +3195,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 				junk += tag
 
 				# print("/", tag.lower(), stack[-1][1].lower())
-				if stack[-1][1] == tag.lower():
+				if stack[-1][0] == tag.lower():
 					junk += scanWhite(html)
 					if html and html[0] == ">":
 						html.pop(0)
@@ -3230,24 +3211,19 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 
 		# Append plain text (if not only whitespace)
 		if (text and ((len(text) == 1 and text in ["\t "])
-		              or not all([ch in " \t\r\n" for ch in text]))):
+					  or not all([ch in " \t\r\n" for ch in text]))):
 			# print("text", text)
-			parent.appendChild(TextNode(__convertEncodedText(text)))
+			parent.append(convertEncodedText(text))
 
 		# Create tag
 		if tag:
 			tag = tag.lower()
 			# print("tag", tag)
 
-			# Special handling for tables: A "thead" and "tbody" are already part of table!
-			if tag in ["thead", "tbody"] and isinstance(parent, Table):
-				wdg = getattr(parent, tag[1:])
+			elem = (tag, {}, [])
 
-			# Usual way: Construct new element and chain it into the parent.
-			else:
-				wdg = __tags[tag][0]()
-
-			stack.append((wdg, tag))
+			stack.append(elem)
+			parent.append(elem)
 
 			while html:
 				scanWhite(html)
@@ -3292,62 +3268,142 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False):
 
 							html.pop(0)
 
-					if att == "[name]":
-						# Allow disable binding!
-						if not bindTo:
-							continue
 
-						if val in dir(appendTo):
-							print("Cannot assign name '{}' because it already exists in {}".format(val, appendTo))
-
-						elif not (any([val.startswith(x) for x in
-						               "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "_"])
-						          and all(
-									[x in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789" + "_"
-									 for x in val[1:]])):
-							print("Cannot assign name '{}' because it contains invalid characters".format(val))
-
-						else:
-							setattr(bindTo, val, wdg)
-
-						if debug:
-							print("name '{}' assigned to {}".format(val, bindTo))
-
-					elif att == "class":
-						# print(tag, att, val.split())
-						wdg.addClass(*val.split())
-
-					elif att == "disabled":
-						# print(tag, att, val)
-						if val == "disabled":
-							wdg.disable()
-
-					elif att == "hidden":
-						# print(tag, att, val)
-						if val == "hidden":
-							wdg.hide()
-
-					elif att == "style":
-						for dfn in val.split(";"):
-							if not ":" in dfn:
-								continue
-
-							att, val = dfn.split(":", 1)
-
-							# print(tag, "style", att.strip(), val.strip())
-							wdg["style"][att.strip()] = val.strip()
-
-					elif att.startswith("data-"):
-						wdg["data"][att[5:]] = val
-
+					if att not in stack[-1][1]:
+						stack[-1][1][att] = val
 					else:
-						# print(tag, att, val)
-						wdg[att] = val
+						stack[-1][1][att] += " " + val
 
 				continue
 
+	while stack and stack[-1][0]:
+		stack.pop()
+
+	return stack[0][2]
+
+
+def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
+	"""
+	Parses the provided HTML code according to the objects defined in the html5-library.
+	html can also be pre-compiled by `parseHTML()` so that it executes faster.
+
+	Constructs all objects as DOM nodes. The first level is chained into appendTo.
+	If no appendTo is provided, appendTo will be set to html5.Body().
+
+	If bindTo is provided, objects are bound to this widget.
+
+	```python
+	import html5
+
+	div = html5.Div()
+	html5.parse.fromHTML('''
+		<div>Yeah!
+			<a href="hello world" [name]="myLink" class="trullman bernd" disabled>
+			hah ala malla" bababtschga"
+			<img src="/static/images/icon_home.svg" style="background-color: red;"/>st
+			<em>ah</em>ralla <i>malla tralla</i> da
+			</a>lala
+		</div>''', div)
+
+	div.myLink.appendChild("appended!")
+	```
+	"""
+
+	# Handle defaults
+	if appendTo is None:
+		appendTo = Body()
+
+	if bindTo is None:
+		bindTo = appendTo
+
+	if isinstance(html, str):
+		html = parseHTML(html, debug=debug)
+
+	def replaceVars(txt):
+		if vars:
+			for var, val in vars.items():
+				txt = txt.replace("{{%s}}" % var, val)
+
+		return txt
+
+	def interpret(parent, items):
+		for item in items:
+			if isinstance(item, str):
+				parent.appendChild(TextNode(replaceVars(item)))
+				continue
+
+			tag = item[0]
+			atts = item[1]
+			children = item[2]
+
+			# Special handling for tables: A "thead" and "tbody" are already part of table!
+			if tag in ["thead", "tbody"] and isinstance(parent, Table):
+				wdg = getattr(parent, tag[1:])
+
+			# Usual way: Construct new element and chain it into the parent.
+			else:
+				wdg = __tags[tag][0]()
+
+			for att, val in atts.items():
+				val = replaceVars(val)
+
+				if att == "[name]":
+					# Allow disable binding!
+					if not bindTo:
+						continue
+
+					if val in dir(appendTo):
+						print("Cannot assign name '{}' because it already exists in {}".format(val, appendTo))
+
+					elif not (any([val.startswith(x) for x in
+								   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "_"])
+							  and all(
+								[x in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789" + "_"
+								 for x in val[1:]])):
+						print("Cannot assign name '{}' because it contains invalid characters".format(val))
+					
+					else:
+						setattr(bindTo, val, wdg)
+
+					if debug:
+						print("name '{}' assigned to {}".format(val, bindTo))
+
+				elif att == "class":
+					# print(tag, att, val.split())
+					wdg.addClass(*val.split())
+
+				elif att == "disabled":
+					# print(tag, att, val)
+					if val == "disabled":
+						wdg.disable()
+
+				elif att == "hidden":
+					# print(tag, att, val)
+					if val == "hidden":
+						wdg.hide()
+
+				elif att == "style":
+					for dfn in val.split(";"):
+						if ":" not in dfn:
+							continue
+
+						att, val = dfn.split(":", 1)
+
+						# print(tag, "style", att.strip(), val.strip())
+						wdg["style"][att.strip()] = val.strip()
+
+				elif att.startswith("data-"):
+					wdg[att[5:]] = val
+
+				else:
+					wdg[att] = val
+
+			interpret(wdg, children)
+
 			if not wdg.parent():
 				parent.appendChild(wdg)
+
+	interpret(appendTo, html)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Bugfix: HTML-parser accepts tags in upper-/camel-case order now.
- Bugfix: HTML-parser handles table tags with tbody/thead tags inside more gracefully.
- Feature: Split HTML-parser into separate stages to compile and run; This allows to pre-compile HTML into a list/dict-structure and render it later on without parsing it again. `parseHTML()` is the new function, `fromHTML()` works like before and handles pre-compiled or raw HTML as parameter.
- Feature: `fromHTML()` extended to `vars` parameter to replace key-value pairs in text-nodes and attribute values expressed as `{{key}}`.