### PR TITLE
New function `html5.Widget.onBind()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This is the current development version.
   - vars: Variables for the HTML-code
   - appendTo: Directly append the widget into other widget
   - bindTo: Bind parsed elements to different widget
+  - style: Class names for styling added to the new Widget, using `Widget.addClass()`
 - Feature: `html5.Widget.appendChild()` and `html5.Widget.prependChild()` can handle arbitrary input now, including HTML, lists of widgets or just text, in any order. `html5.Widget.insertChild()` runs slightly different, but shares same features. This change mostly supersedes `html5.Widget.fromHTML()`.
 - Feature: New `replace`-parameter for `html5.Widget.appendChild()` and `html5.Widget.prependChild()` which clears the content
 - Feature: `html5.ext.InputDialog` refactored & disables OK-Button when no value is present 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,11 @@
 
 This file documents any relevant changes done to ViUR html5 since version 2.
 
-## [develop]
+## 3.0.0 [develop]
 
 This is the current development version.
 
-- Feature: Ported framework to Python 3 using [Pyodide](https://github.com/iodide-project/pyodide)
-- Feature: Full library clean-up
+- Feature: Ported framework to Python 3 using [Pyodide](https://github.com/iodide-project/pyodide), with a full source code and library cleanup
 - Feature: `html5.Widget.__init__()` now provides parameters for
   - html: HTML-body code to be appended to the widget
   - vars: Variables for the HTML-code
@@ -17,6 +16,7 @@ This is the current development version.
 - Feature: New `replace`-parameter for `html5.Widget.appendChild()` and `html5.Widget.prependChild()` which clears the content
 - Feature: `html5.ext.InputDialog` refactored & disables OK-Button when no value is present 
 - Feature: `html5.utils.doesEventHitWidgetOrChildren()` and `html5.utils.doesEventHitWidgetOrParent()` now return the Widget or None instead of a boolean, to avoid creating loops and directly work with the recognized Widget. 
+- Feature: New function `html5.Widget.onBind()` enables widgets to react when bound to other widgets using the HTML parser.
 
 ## [2.5.0] Vesuv
 

--- a/core.py
+++ b/core.py
@@ -240,7 +240,7 @@ class Widget(object):
 	_baseClass = None
 	_namespace = None
 
-	def __init__(self, html=None, appendTo=None, bindTo=None, vars=None, **kwargs):
+	def __init__(self, html=None, appendTo=None, bindTo=None, vars=None, style=None, **kwargs):
 		if "_wrapElem" in kwargs.keys():
 			self.element = kwargs["_wrapElem"]
 			del kwargs["_wrapElem"]
@@ -249,6 +249,8 @@ class Widget(object):
 			self.element = domCreateElement(self._baseClass, ns=self._namespace)
 
 		super().__init__()
+		if style:
+			self.addClass(style)
 
 		self._children = []
 		self._catchedEvents = {}

--- a/core.py
+++ b/core.py
@@ -3069,7 +3069,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
 					if not bindTo:
 						continue
 
-					if val in dir(bindTo):
+					if getattr(bindTo, val, None):
 						print("Cannot assign name '{}' because it already exists in {}".format(val, bindTo))
 
 					elif not (any([val.startswith(x) for x in

--- a/core.py
+++ b/core.py
@@ -631,6 +631,13 @@ class Widget(object):
 		"""
 		return not self.isHidden()
 
+	def onBind(self, widget, name):
+		"""
+		Event function that is called on the widget when it is bound to another widget with a name.
+		This is only done by the HTML parser, a manual binding by the user is not triggered.
+		"""
+		return
+
 	def onAttach(self):
 		self._isAttached = True
 
@@ -810,9 +817,9 @@ class Widget(object):
 
 		for item in args:
 			if isinstance(item, list):
-				self.addClass(item)
+				self.addClass(*item)
 
-			elif isinstance(item, str) or isinstance(item, unicode):
+			elif isinstance(item, str):
 				for sitem in item.split(" "):
 					if not self.hasClass(sitem):
 						self["class"].append(sitem)
@@ -831,7 +838,7 @@ class Widget(object):
 			if isinstance(item, list):
 				self.removeClass(item)
 
-			elif isinstance(item, str) or isinstance(item, unicode):
+			elif isinstance(item, str):
 				for sitem in item.split(" "):
 					if self.hasClass(sitem):
 						self["class"].remove(sitem)
@@ -3072,6 +3079,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
 
 					else:
 						setattr(bindTo, val, wdg)
+						wdg.onBind(bindTo, val)
 
 					if debug:
 						print("name '{}' assigned to {}".format(val, bindTo))


### PR DESCRIPTION
This new function enables widgets to react when bound to other widgets using the HTML parser.

This custom Button widget implementation
```python
@html5.tag
class Button(html5.Button):
    def __init__(self, callback=None):
        super(Button, self).__init__()
        self.addClass("btn")
        self.sinkEvent("onClick")

        self.callback = callback

    def onBind(self, widget, name):
        if self.callback is None:
            funcName = "on" + name[0].upper() + name[1:] + "Click"
            if funcName in dir(widget):
                self.callback = getattr(widget, funcName)

    def onClick(self, event):
        event.stopPropagation()
        event.preventDefault()

        if self.callback is not None:
            try:
                self.callback(self)
            except TypeError:
                self.callback()
```
can then be used including functional event code this way in other Widgets:
```python
class Demo(html5.Div):

    def __init__(self, widget):
        super().__init__("""<button [name]="demoBtn" class="btn-demo">Say Hello</button>""")

    def onDemoBtnClick(self):
        html5.ext.Alert("Hello World")
```

Some unicode type checks where also removed due abandoned support in Python 3.