### PR TITLE
Replace HTML-parsing vars-parameter by **kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,15 @@ This is the current development version.
 - Feature: Ported framework to Python 3 using [Pyodide](https://github.com/iodide-project/pyodide), with a full source code and library cleanup
 - Feature: `html5.Widget.__init__()` now allows parameters equal to `Widget.appendChild()` to directly stack widgets together.
   Additionally, the following parameters are available:
-  - `appendTo`: Directly append the newly created widget to another widget
-  - `style`: Provide class attributes for styling added to the new Widget, using `Widget.addClass()`
+  - `appendTo`: Directly append the newly created widget to another widget.
+  - `style`: Provide class attributes for styling added to the new Widget, using `Widget.addClass()`.
 - Feature: `html5.Widget.appendChild()` and `html5.Widget.prependChild()` can handle arbitrary input now, including HTML, lists of widgets or just text, in any order. `html5.Widget.insertChild()` runs slightly different, but shares same features. This change mostly supersedes `html5.Widget.fromHTML()`.
-- Feature: New `replace`-parameter for `html5.Widget.appendChild()` and `html5.Widget.prependChild()` which clears the content
-- Feature: `html5.ext.InputDialog` refactored & disables OK-Button when no value is present 
+- Feature: New `replace`-parameter for `html5.Widget.appendChild()` and `html5.Widget.prependChild()` which clears the content.
+- Feature: `html5.ext.InputDialog` refactored & disables OK-Button when no value is present.
 - Feature: `html5.utils.doesEventHitWidgetOrChildren()` and `html5.utils.doesEventHitWidgetOrParent()` now return the Widget or None instead of a boolean, to avoid creating loops and directly work with the recognized Widget. 
 - Feature: New function `html5.Widget.onBind()` enables widgets to react when bound to other widgets using the HTML parser.
-- Speed-improvement: Hold one static _WidgetClassWrapper per widget instead of creating one each time on the fly
+- Feature: Replace HTML-parsing-related `vars`-parameter generally by `**kwargs`, with backward-compatibility.
+- Speed-improvement: Hold static `_WidgetClassWrapper` per `html5.Widget` instead of creating one each time on the fly.
 
 ## [2.5.0] Vesuv
 

--- a/core.py
+++ b/core.py
@@ -1031,15 +1031,16 @@ class Widget(object):
 			self.element.removeChild(c.element)
 			self.element.insertBefore(c.element, self.element.children.item(0))
 
-	def fromHTML(self, html, appendTo=None, bindTo=None, vars=None, replace=False):
+	def fromHTML(self, html, appendTo=None, bindTo=None, replace=False, vars=None, **kwargs):
 		"""
 		Parses html and constructs its elements as part of self.
 
 		:param html: HTML code.
 		:param appendTo: The entity where the HTML code is constructed below. This defaults to self in usual case.
 		:param bindTo: The entity where the named objects are bound to. This defaults to self in usual case.
-		:param vars: Additional variables provided as a dict for {{placeholders}} inside the HTML
 		:param replace: Clear entire content of appendTo before appending.
+		:param vars: Deprecated; Same as kwargs.
+		:param **kwargs: Additional variables provided as a dict for {{placeholders}} inside the HTML
 
 		:return:
 		"""
@@ -1052,7 +1053,11 @@ class Widget(object):
 		if replace:
 			appendTo.removeAllChildren()
 
-		return fromHTML(html, appendTo=appendTo, bindTo=bindTo, vars=vars)
+		# use of vars is deprecated!
+		if isinstance(vars, dict):
+			kwargs.update(vars)
+
+		return fromHTML(html, appendTo=appendTo, bindTo=bindTo, **kwargs)
 
 
 ########################################################################################################################
@@ -3006,7 +3011,7 @@ def parseHTML(html, debug=False):
 
 	return stack[0][2]
 
-def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
+def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs):
 	"""
 	Parses the provided HTML code according to the objects defined in the html5-library.
 	html can also be pre-compiled by `parseHTML()` so that it executes faster.
@@ -3042,10 +3047,12 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None):
 
 	assert isinstance(html, HtmlAst)
 
+	if isinstance(vars, dict):
+		kwargs.update(vars)
+
 	def replaceVars(txt):
-		if vars:
-			for var, val in vars.items():
-				txt = txt.replace("{{%s}}" % var, str(val) if val is not None else "")
+		for var, val in kwargs.items():
+			txt = txt.replace("{{%s}}" % var, str(val) if val is not None else "")
 
 		return txt
 


### PR DESCRIPTION
This commit is backward-compatible and merges vars into kwargs when provided.
It should be considered to entirely remove vars, altought it is used in some presentations and workshops already.

Resolves #15.