### PR TITLE
Feature/htmltag databinding

### DIFF
--- a/core.py
+++ b/core.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*
+import logging
 
 ########################################################################################################################
 # DOM-access functions and variables
@@ -2920,11 +2921,13 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 					wdg["data"][att[5:]] = val
 
 				elif att.startswith(":"):
-					attrName = att[1:]
-					attrVal = val
-
-					refObj = getattr(bindTo, attrVal)
-					setattr(wdg, attrName, refObj)
+					if bindTo:
+						try:
+							setattr(wdg, att[1:], getattr(bindTo, val))
+						except Exception as e:
+							logging.exception(e)
+					else:
+						logging.error("html5: bindTo is unset, can't use %r here", att)
 
 				else:
 					wdg[att] = parseInt(val, val)

--- a/core.py
+++ b/core.py
@@ -2770,7 +2770,7 @@ def parseHTML(html, debug=False):
 					html.pop(0)
 					continue
 
-				if att in __tags[tag][1] or att in ["[name]", "style", "disabled", "hidden"] or att.startswith("data-"):
+				if att in __tags[tag][1] or att in ["[name]", "style", "disabled", "hidden"] or att.startswith("data-") or att.startswith(":"):
 					scanWhite(html)
 					if html[0] == "=":
 						html.pop(0)
@@ -2918,6 +2918,13 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 
 				elif att.startswith("data-"):
 					wdg["data"][att[5:]] = val
+
+				elif att.startswith(":"):
+					attrName = att[1:]
+					attrVal = val
+
+					refObj = getattr(bindTo, attrVal)
+					setattr(wdg, attrName, refObj)
 
 				else:
 					wdg[att] = parseInt(val, val)

--- a/ignite.py
+++ b/ignite.py
@@ -7,7 +7,7 @@ class Label(html5.Label):
 	_parserTagName = "ignite-label"
 
 	def __init__(self, *args, **kwargs):
-		super(Label, self).__init__(style="label ignt-label", *args, **kwargs)
+		super(Label, self).__init__(style="label flr-label", *args, **kwargs)
 
 
 @html5.tag
@@ -15,7 +15,7 @@ class Input(html5.Input):
 	_parserTagName = "ignite-input"
 
 	def __init__(self, *args, **kwargs):
-		super(Input, self).__init__(style="input ignt-input", *args, **kwargs)
+		super(Input, self).__init__(style="input flr-input", *args, **kwargs)
 
 
 @html5.tag
@@ -23,7 +23,7 @@ class Switch(html5.Div):
 	_parserTagName = "ignite-switch"
 
 	def __init__(self, *args, **kwargs):
-		super(Switch, self).__init__(style="switch ignt-switch", *args, **kwargs)
+		super(Switch, self).__init__(style="switch flr-switch", *args, **kwargs)
 
 		self.input = html5.Input(style="switch-input")
 		self.appendChild(self.input)
@@ -45,7 +45,7 @@ class Check(html5.Input):
 	_parserTagName = "ignite-check"
 
 	def __init__(self, *args, **kwargs):
-		super(Check, self).__init__(style="check ignt-check", *args, **kwargs)
+		super(Check, self).__init__(style="check flr-check", *args, **kwargs)
 
 		checkInput = html5.Input()
 		checkInput.addClass("check-input")
@@ -62,7 +62,7 @@ class Radio(html5.Div):
 	_parserTagName = "ignite-radio"
 
 	def __init__(self, *args, **kwargs):
-		super(Radio, self).__init__(style="radio ignt-radio", *args, **kwargs)
+		super(Radio, self).__init__(style="radio flr-radio", *args, **kwargs)
 
 		radioInput = html5.Input()
 		radioInput.addClass("radio-input")
@@ -79,7 +79,7 @@ class Select(html5.Select):
 	_parserTagName = "ignite-select"
 
 	def __init__(self, *args, **kwargs):
-		super(Select, self).__init__(style="select ignt-select", *args, **kwargs)
+		super(Select, self).__init__(style="select flr-select", *args, **kwargs)
 
 		defaultOpt = html5.Option()
 		defaultOpt["selected"] = True
@@ -93,7 +93,7 @@ class Textarea(html5.Textarea):
 	_parserTagName = "ignite-textarea"
 
 	def __init__(self, *args, **kwargs):
-		super(Textarea, self).__init__(style="textarea ignt-textarea", *args, **kwargs)
+		super(Textarea, self).__init__(style="textarea flr-textarea", *args, **kwargs)
 
 
 @html5.tag
@@ -101,7 +101,7 @@ class Progress(html5.Progress):
 	_parserTagName = "ignite-progress"
 
 	def __init__(self, *args, **kwargs):
-		super(Progress, self).__init__(style="progress ignt-progress", *args, **kwargs)
+		super(Progress, self).__init__(style="progress flr-progress", *args, **kwargs)
 
 
 @html5.tag
@@ -109,15 +109,15 @@ class Item(html5.Div):
 	_parserTagName = "ignite-item"
 
 	def __init__(self, title=None, descr=None, className=None, *args, **kwargs):
-		super(Item, self).__init__(style="item ignt-item", *args, **kwargs)
+		super(Item, self).__init__(style="item flr-item", *args, **kwargs)
 		if className:
 			self.addClass(className)
 
 		self.fromHTML("""
-			<div class="item-image ignt-item-image" [name]="itemImage">
+			<div class="item-image flr-item-image" [name]="itemImage">
 			</div>
-			<div class="item-content ignt-item-content" [name]="itemContent">
-				<div class="item-headline ignt-item-headline" [name]="itemHeadline">
+			<div class="item-content flr-item-content" [name]="itemContent">
+				<div class="item-headline flr-item-headline" [name]="itemHeadline">
 				</div>
 			</div>
 		""")
@@ -127,7 +127,7 @@ class Item(html5.Div):
 
 		if descr:
 			self.itemSubline = html5.Div()
-			self.addClass("item-subline ignt-item-subline")
+			self.addClass("item-subline flr-item-subline")
 			self.itemSubline.appendChild(html5.TextNode(descr))
 			self.appendChild(self.itemSubline)
 
@@ -138,8 +138,8 @@ class Table(html5.Table):
 
 	def __init__(self, *args, **kwargs):
 		super(Table, self).__init__(*args, **kwargs)
-		self.head.addClass("ignt-table-head")
-		self.body.addClass("ignt-table-body")
+		self.head.addClass("flr-table-head")
+		self.body.addClass("flr-table-body")
 
 	def prepareRow(self, row):
 		assert row >= 0, "Cannot create rows with negative index"
@@ -151,7 +151,7 @@ class Table(html5.Table):
 
 		while row >= 0:
 			tableRow = html5.Tr()
-			tableRow.addClass("ignt-table-body-row")
+			tableRow.addClass("flr-table-body-row")
 			self.body.appendChild(tableRow)
 			row -= 1
 
@@ -170,17 +170,17 @@ class Table(html5.Table):
 
 				while col >= 0:
 					tableCell = html5.Td()
-					tableCell.addClass("ignt-table-body-cell")
+					tableCell.addClass("flr-table-body-cell")
 					rowChild.appendChild(tableCell)
 					col -= 1
 
 				return
 	def fastGrid( self, rows, cols, createHidden=False ):
-		colsstr = "".join(['<td class="ignt-table-body-cell"></td>' for i in range(0, cols)])
-		tblstr = '<tbody [name]="body" class="ignt-table-body" >'
+		colsstr = "".join(['<td class="flr-table-body-cell"></td>' for i in range(0, cols)])
+		tblstr = '<tbody [name]="body" class="flr-table-body" >'
 
 		for r in range(0, rows):
-			tblstr += '<tr class="ignt-table-body-row %s">%s</tr>' %("is-hidden" if createHidden else "",colsstr)
+			tblstr += '<tr class="flr-table-body-row %s">%s</tr>' %("is-hidden" if createHidden else "",colsstr)
 		tblstr +="</tbody>"
 
 		self.fromHTML(tblstr)


### PR DESCRIPTION
html tags can now have arguments preceded by a colon. These arguments are used for databinding.

i.e.:

```python
self.skel = skelObj
self.structure = skelStructureObj

self.appendChild( '''
	<viurForm [name]="testform" :askel="skel" :astructure="structure">
''')
```

skelObj and skelStructureObj are now available in viurForm-Tag with name askel and astructure



