### PR TITLE
HTML-parser: Direct attribute assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This file documents any relevant changes done to ViUR html5 since version 2.
 This is the current development version.
 
 - Feature: Changed LGPLv3 licensing terms into MIT
-- Feature: Ported framework to Python 3 using [Pyodide](https://github.com/iodide-project/pyodide), with a full source code and library cleanup
+- Feature: Ported framework to Python 3.7 using [Pyodide](https://github.com/iodide-project/pyodide), with a full source code and library cleanup
 - Feature: `html5.Widget.__init__()` now allows for parameters equal to `Widget.appendChild()` to directly stack widgets together.
   Additionally, the following parameters can be used:
   - `appendTo`: Directly append the newly created widget to another widget.
@@ -20,6 +20,9 @@ This is the current development version.
 - Feature: Replace HTML-parsing-related `vars`-parameter generally by `**kwargs`, with backward-compatibility.
 - Feature: Splitting SVG-Widgets into separate module.
 - Feature: Replaced `_isVoid`-class by class-attribute `Widget._leafTag` for easier leaf-widget-/tag configuration outside of html5.
+- Feature: HTML-parser improvements
+  - Direct attribute assignments: Store attributes which are not HTML-element attributes directly, e.g. `<div kind="internal">` becomes `self.kind = "internal"` on the created `html5.Div()` instance
+  - ':'-notation on attributes to transfer objects from binder to its children
 - Speed-improvement: Hold static `_WidgetClassWrapper` per `html5.Widget` instead of creating one each time on the fly.
 
 ## [2.5.0] Vesuv

--- a/core.py
+++ b/core.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*
-import logging
+import logging, string
 
 ########################################################################################################################
 # DOM-access functions and variables
@@ -2786,25 +2786,24 @@ def parseHTML(html, debug=False):
 					html.pop(0)
 					continue
 
-				if att in __tags[tag][1] or att in ["[name]", "style", "disabled", "hidden"] or att.startswith("data-") or att.startswith(":"):
+				scanWhite(html)
+				if html[0] == "=":
+					html.pop(0)
 					scanWhite(html)
-					if html[0] == "=":
+
+					if html[0] in "\"'":
+						ch = html.pop(0)
+
+						val = ""
+						while html and html[0] != ch:
+							val += html.pop(0)
+
 						html.pop(0)
-						scanWhite(html)
 
-						if html[0] in "\"'":
-							ch = html.pop(0)
-
-							val = ""
-							while html and html[0] != ch:
-								val += html.pop(0)
-
-							html.pop(0)
-
-					if att not in elem[1]:
-						elem[1][att] = val
-					else:
-						elem[1][att] += " " + val
+				if att not in elem[1]:
+					elem[1][att] = val
+				else:
+					elem[1][att] += " " + val
 
 				continue
 
@@ -2886,28 +2885,28 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 			for att, val in atts.items():
 				val = replaceVars(val)
 
+				# The [name] attribute binds the current widget to bindTo under the provided name!
 				if att == "[name]":
 					# Allow disable binding!
 					if not bindTo:
+						logging.warning("html5: Unable to evaluate %r due unset bindTo", att)
 						continue
 
 					if getattr(bindTo, val, None):
-						print("Cannot assign name '{}' because it already exists in {}".format(val, bindTo))
+						logging.warning("html5: Cannot assign name %r because it already exists in %r", val, bindTo)
 
-					elif not (any([val.startswith(x) for x in
-								   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "_"])
-							  and all(
-								[x in "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz" + "0123456789" + "_"
-								 for x in val[1:]])):
-						print("Cannot assign name '{}' because it contains invalid characters".format(val))
+					elif not (any([val.startswith(x) for x in string.ascii_letters + "_"])
+							  and all([x in string.ascii_letters + string.digits + "_" for x in val[1:]])):
+						logging.warning("html5: Cannot assign name %r because it contains invalid characters", val)
 
 					else:
 						setattr(bindTo, val, wdg)
 						wdg.onBind(bindTo, val)
 
-					if debug:
-						print("name '{}' assigned to {}".format(val, bindTo))
+					if debug: #fixme: remove debug flag!
+						logging.debug("html5: %r assigned to %r", val, bindTo)
 
+				# Class is handled via Widget.addClass()
 				elif att == "class":
 					# print(tag, att, val.split())
 					wdg.addClass(*val.split())
@@ -2922,6 +2921,7 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 					if val == "hidden":
 						wdg.hide()
 
+				# style-attributes must be split into its separate parts to be mapped into the dict.
 				elif att == "style":
 					for dfn in val.split(";"):
 						if ":" not in dfn:
@@ -2932,9 +2932,11 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 						# print(tag, "style", att.strip(), val.strip())
 						wdg["style"][att.strip()] = val.strip()
 
+				# data attributes are mapped into a related dict.
 				elif att.startswith("data-"):
 					wdg["data"][att[5:]] = val
 
+				# transfer attributes from the binder into current widget
 				elif att.startswith(":"):
 					if bindTo:
 						try:
@@ -2944,8 +2946,19 @@ def fromHTML(html, appendTo=None, bindTo=None, debug=False, vars=None, **kwargs)
 					else:
 						logging.error("html5: bindTo is unset, can't use %r here", att)
 
+				# Otherwise, either store widget attribute or save value on widget.
 				else:
-					wdg[att] = parseInt(val, val)
+					try:
+						wdg[att] = parseInt(val, val)
+
+					except ValueError:
+						if att in dir(wdg):
+							logging.error("html5: Attribute %r already defined for %r", att, wdg)
+						else:
+							setattr(wdg, att, val)
+
+					except Exception as e:
+						logging.exception(e)
 
 			interpret(wdg, children)
 


### PR DESCRIPTION
Store attributes which are not HTML-element attributes directly in the widget, e.g. `<div kind="internal">` becomes `self.kind = "internal"` on the created `html5.Div()` instance.

This pull request resolves #18