### PR TITLE
wrong Input maxLength property name

### DIFF
--- a/core.py
+++ b/core.py
@@ -1241,10 +1241,10 @@ class _attrFor(object):
 
 class _attrInputs(_attrRequired):
 	def _getMaxlength(self):
-		return self.element.maxlength
+		return self.element.maxLength
 
 	def _setMaxlength(self, val):
-		self.element.maxlength = val
+		self.element.maxLength = val
 
 	def _getPlaceholder(self):
 		return self.element.placeholder


### PR DESCRIPTION
wheras the HTML tag attribute is maxlength in lowercase https://www.w3schools.com/tags/att_textarea_maxlength.asp , the DOM object property is maxLength with capital L https://www.w3schools.com/jsref/prop_textarea_maxlength.asp